### PR TITLE
メソッドの修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,12 +1,11 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_prototype, only: [:edit, :show]
   def index
-    # @prototype = Prototype.new
-    @prototypes = Prototype.all
+    @prototypes = Prototype.includes(:user)
   end
 
   def show
-    @prototype = Prototype.find(params[:id])
     @comment = Comment.new
     @comments = @prototype.comments.includes(:user)
   end
@@ -25,7 +24,6 @@ class PrototypesController < ApplicationController
   end
 
   def edit
-    @prototype = Prototype.find(params[:id])
     unless user_signed_in?
       redirect_to action: :index
     end
@@ -51,4 +49,7 @@ class PrototypesController < ApplicationController
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
 
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
+  end
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,8 +4,9 @@
       <p class="prototype__hedding">
         <%= link_to @prototype.title, root_path%>
       </p>
+      <%= link_to "by #{@prototype.user.name}" , user_path(@prototype.user.id), class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
-      <%= link_to "by #{@prototypes.user.name}" , user_path(prototype.user.id), class: :prototype__user %>
+      
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       
         <div class="prototype__manage">
@@ -52,7 +53,7 @@
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
           <% @comments.each do |comment| %>
             <li class="comments_list">
-               <%= comment.content %><%= link_to "(#{comment.user.name})", root_path, class: :comment_user %><br />
+               <%= comment.content %><%= link_to "(#{comment.user.name})", user_path(comment.user.id), class: :comment_user %><br />
             </li>
           <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>


### PR DESCRIPTION
# 概要
・prototypeのN+1問題の解消とbefore_actionを使い繰り返しコードの記述を削除
・投稿者名を押すときちんとそのユーザーの名前の詳細ページへ遷移できるように記述を修正